### PR TITLE
Added AMD-64 cross-compiled stalin-.c file, makes ./build "turnkey" on a 64-bit Ubuntu

### DIFF
--- a/benchmarks/compile-and-run-stalin-benchmark
+++ b/benchmarks/compile-and-run-stalin-benchmark
@@ -3,6 +3,9 @@ unset noclobber
 ulimit -s unlimited
 ulimit -c 0
 case `uname -m` in
+  x86_64)
+    s="-d0 -d1 -d5 -d6 -Ob -Om -On -Or -Ot -k -architecture AMD64"
+    c="-copt -O3 -copt -fomit-frame-pointer -copt -Wall -copt -freg-struct-return";;
   i[3456]86)
     s="-d0 -d1 -d5 -d6 -Ob -Om -On -Or -Ot -k -architecture IA32"
     c="-copt -O3 -copt -fomit-frame-pointer -copt -Wall -copt -freg-struct-return";;


### PR DESCRIPTION
... and benchmarks/compile-and-run-stalin-old-benchmarks benchmarks seems to compile and run after adding AMD64 to the list of cases.
